### PR TITLE
Expose csv in transactionview (CSV export support)

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -605,6 +605,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return rec->status.countsForBalance;
     case FormattedAmountRole:
         return formatTxAmount(rec, false);
+    case NoteRole:
+        return formatNote(rec);
     case StatusRole:
         return rec->status.status;
     }

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -49,6 +49,8 @@ public:
         ConfirmedRole,
         /** Formatted amount, without brackets when unconfirmed */
         FormattedAmountRole,
+        /** Note field as a converted string */
+        NoteRole,
         /** Transaction status (TransactionRecord::Status) */
         StatusRole
     };

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -287,6 +287,10 @@ void TransactionView::updateTotalAmount()
 
 void TransactionView::exportClicked()
 {
+    if (!model || !model->getOptionsModel()) {
+        return;
+    }
+
     // CSV is currently the only supported format
     QString filename = GUIUtil::getSaveFileName(
             this,

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -46,6 +46,11 @@ TransactionView::TransactionView(QWidget *parent) :
     hlayout->addSpacing(23);
 #endif
 
+    // Export button exposes CSV export functionality
+    QPushButton *exportButton = new QPushButton(tr("&Export"), this);
+    exportButton->setToolTip(tr("Export the data in the current tab to a file"));
+    hlayout->addWidget(exportButton);
+
     dateWidget = new QComboBox(this);
 #ifdef Q_OS_MAC
     dateWidget->setFixedWidth(101);
@@ -140,6 +145,8 @@ TransactionView::TransactionView(QWidget *parent) :
     contextMenu->addAction(showDetailsAction);
 
     // Connect actions
+    connect(exportButton, SIGNAL(clicked()), this, SLOT(exportClicked()));
+
     connect(dateWidget, SIGNAL(activated(int)), this, SLOT(chooseDate(int)));
     connect(typeWidget, SIGNAL(activated(int)), this, SLOT(chooseType(int)));
     connect(addressWidget, SIGNAL(textChanged(QString)), this, SLOT(changedPrefix(QString)));
@@ -308,6 +315,7 @@ void TransactionView::exportClicked()
     writer.addColumn(tr("Type"), TransactionTableModel::Type, Qt::EditRole);
     writer.addColumn(tr("Label"), 0, TransactionTableModel::LabelRole);
     writer.addColumn(tr("Address"), 0, TransactionTableModel::AddressRole);
+    writer.addColumn(tr("Note"), 0, TransactionTableModel::NoteRole);
     writer.addColumn(tr("Amount"), 0, TransactionTableModel::FormattedAmountRole);
     writer.addColumn(tr("ID"), 0, TransactionTableModel::TxIDRole);
 


### PR DESCRIPTION
Adds fix for potential null pointer in transaction view as per https://github.com/bitcoin/bitcoin/pull/9549
Adds export button exposing the native export functionality
Adds note field to export functionality